### PR TITLE
Security fix for the reported issue in patchstack

### DIFF
--- a/beacon-by.php
+++ b/beacon-by.php
@@ -10,10 +10,8 @@ License: GPL v2 (or later)
 copyright 2016 beacon.by
 */
 
-
-// Make sure we don't expose any info if called directly
-if ( !function_exists( 'add_action' ) ) {
-	echo 'Hi there!  I\'m just a plugin, not much I can do when called directly.';
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 

--- a/classes/class.beacon_plugin.php
+++ b/classes/class.beacon_plugin.php
@@ -1,4 +1,8 @@
-<?php defined( 'ABSPATH' ) or die( '' );
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Beacon plugin class
@@ -359,11 +363,11 @@ class Beacon_plugin {
 
 
 		// $posts = get_posts( array(
-		// 	'numberposts' => $num_posts, 
-		// 	'order_by' => 'date',
-		// 	'order' => $order,
-		// 	'fields' => array('post_title', 'comment_status'),
-		// 	'post_type' => array('page', 'post')) );
+		//  'numberposts' => $num_posts, 
+		//  'order_by' => 'date',
+		//  'order' => $order,
+		//  'fields' => array('post_title', 'comment_status'),
+		//  'post_type' => array('page', 'post')) );
 		$posts = array();
 		
 
@@ -478,7 +482,7 @@ class Beacon_plugin {
 			foreach ( $_POST as $k => $v ) {
 				$k = esc_html( $k );
 				$v = esc_html( $v );
-				$post[$k] = $v;	
+				$post[$k] = $v; 
 			}
 
 			$serialized = serialize( $post) ;

--- a/classes/class.beacon_widget.php
+++ b/classes/class.beacon_widget.php
@@ -1,5 +1,8 @@
-<?php defined( 'ABSPATH' ) or die( '' );
-
+<?php
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Beacon widget class
@@ -83,7 +86,7 @@ class Beacon_widget extends WP_Widget {
 		$data = ($data) ? $data : array();
 		// extract($data);
 		ob_start();
-		require($view);			
+		require($view);         
 		$view = ob_get_contents();
 		ob_end_clean();
 

--- a/config.php
+++ b/config.php
@@ -1,5 +1,9 @@
 <?php 
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 //Prevent directly browsing to the file
 if (function_exists('plugin_dir_url')) 
@@ -23,11 +27,11 @@ if (function_exists('plugin_dir_url'))
 	define("BEACONBY_HELPLINK",     "https://beacon.by/wordpress");
 	define('BEACONBY_PLUGIN_URL',   plugin_dir_url(__FILE__));
 	define('BEACONBY_PLUGIN_PATH',  plugin_dir_path(__FILE__));
-	define('BEACONBY_SITE_URL',	get_site_url());
+	define('BEACONBY_SITE_URL', get_site_url());
 	define('BEACONBY_INCLUDE_TITLES', true);
-	define('BEACONBY_PER_PAGE',	50);
+	define('BEACONBY_PER_PAGE', 50);
 
-	define('BEACONBY_CREATE_TARGET',	$create_target);
+	define('BEACONBY_CREATE_TARGET',    $create_target);
 
 }
 

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/views/dashboard/authorize.php
+++ b/views/dashboard/authorize.php
@@ -23,7 +23,7 @@
 		<!-- <button class="button large">I understand, let's get started! &raquo;</button> -->
 	<!-- </form> -->
 
-	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
+	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/wordpress' ); ?>" method="post">
 		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
 		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Let's Connect</button>

--- a/views/dashboard/authorize.php
+++ b/views/dashboard/authorize.php
@@ -24,8 +24,8 @@
 	<!-- </form> -->
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo $_SERVER['HTTP_HOST']; ?>" />
-		<input type="hidden" name="ref" value="<?php echo Beacon_plugin::getPageURL(); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_attr( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Let's Connect</button>
 	</form>
 

--- a/views/dashboard/authorize.php
+++ b/views/dashboard/authorize.php
@@ -24,8 +24,8 @@
 	<!-- </form> -->
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
-		<input type="hidden" name="ref" value="<?php echo esc_attr( Beacon_plugin::getPageURL() ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_attr( esc_url( Beacon_plugin::getPageURL() ) ); ?>" />
 		<button class="button large">Let's Connect</button>
 	</form>
 

--- a/views/dashboard/authorize.php
+++ b/views/dashboard/authorize.php
@@ -24,8 +24,8 @@
 	<!-- </form> -->
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>" />
-		<input type="hidden" name="ref" value="<?php echo esc_attr( esc_url( Beacon_plugin::getPageURL() ) ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Let's Connect</button>
 	</form>
 

--- a/views/dashboard/authorize.php
+++ b/views/dashboard/authorize.php
@@ -24,7 +24,7 @@
 	<!-- </form> -->
 
 	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/wordpress' ); ?>" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
 		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Let's Connect</button>
 	</form>

--- a/views/dashboard/connect.php
+++ b/views/dashboard/connect.php
@@ -45,7 +45,7 @@
 	<p> Connect WordPress to your Beacon account so you can convert blog posts into lead magnets.  </p>
 
 	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/wordpress' ); ?>" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
 		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Connect</button>
 	</form>
@@ -55,7 +55,7 @@
 	<p class="large flush">I don't have a Beacon account </p>
 
 	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/register-wordpress' ); ?>" method="post">
-		<input type="hidden" name="page" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>"/>
+		<input type="hidden" name="page" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>"/>
 		<input type="hidden" name="domain" value="<?php echo esc_url( $_SERVER['PHP_SELF'] ); ?>"/>
 		<button type="submit" class="text-button">Create a free account &gt;</button>
 	</form>

--- a/views/dashboard/connect.php
+++ b/views/dashboard/connect.php
@@ -45,8 +45,8 @@
 	<p> Connect WordPress to your Beacon account so you can convert blog posts into lead magnets.  </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo $_SERVER['HTTP_HOST']; ?>" />
-		<input type="hidden" name="ref" value="<?php echo Beacon_plugin::getPageURL(); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_attr( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Connect</button>
 	</form>
 
@@ -55,8 +55,8 @@
 	<p class="large flush">I don't have a Beacon account </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/register-wordpress" method="post">
-		<input type="hidden" name="page" value="<?php echo $_SERVER['HTTP_HOST']; ?>"/>
-		<input type="hidden" name="domain" value="<?php echo $_SERVER['PHP_SELF']; ?>"/>
+		<input type="hidden" name="page" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>"/>
+		<input type="hidden" name="domain" value="<?php echo esc_attr( $_SERVER['PHP_SELF'] ); ?>"/>
 		<button type="submit" class="text-button">Create a free account &gt;</button>
 	</form>
 	<br />

--- a/views/dashboard/connect.php
+++ b/views/dashboard/connect.php
@@ -45,8 +45,8 @@
 	<p> Connect WordPress to your Beacon account so you can convert blog posts into lead magnets.  </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>" />
-		<input type="hidden" name="ref" value="<?php echo esc_attr( Beacon_plugin::getPageURL() ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_attr( esc_url( Beacon_plugin::getPageURL() ) ); ?>" />
 		<button class="button large">Connect</button>
 	</form>
 
@@ -55,8 +55,8 @@
 	<p class="large flush">I don't have a Beacon account </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/register-wordpress" method="post">
-		<input type="hidden" name="page" value="<?php echo esc_attr( $_SERVER['HTTP_HOST'] ); ?>"/>
-		<input type="hidden" name="domain" value="<?php echo esc_attr( $_SERVER['PHP_SELF'] ); ?>"/>
+		<input type="hidden" name="page" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>"/>
+		<input type="hidden" name="domain" value="<?php echo esc_attr( esc_url( $_SERVER['PHP_SELF'] ) ); ?>"/>
 		<button type="submit" class="text-button">Create a free account &gt;</button>
 	</form>
 	<br />

--- a/views/dashboard/connect.php
+++ b/views/dashboard/connect.php
@@ -45,8 +45,8 @@
 	<p> Connect WordPress to your Beacon account so you can convert blog posts into lead magnets.  </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
-		<input type="hidden" name="blog" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>" />
-		<input type="hidden" name="ref" value="<?php echo esc_attr( esc_url( Beacon_plugin::getPageURL() ) ); ?>" />
+		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
+		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Connect</button>
 	</form>
 
@@ -55,8 +55,8 @@
 	<p class="large flush">I don't have a Beacon account </p>
 
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/register-wordpress" method="post">
-		<input type="hidden" name="page" value="<?php echo esc_attr( esc_url( $_SERVER['HTTP_HOST'] ) ); ?>"/>
-		<input type="hidden" name="domain" value="<?php echo esc_attr( esc_url( $_SERVER['PHP_SELF'] ) ); ?>"/>
+		<input type="hidden" name="page" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>"/>
+		<input type="hidden" name="domain" value="<?php echo esc_url( $_SERVER['PHP_SELF'] ); ?>"/>
 		<button type="submit" class="text-button">Create a free account &gt;</button>
 	</form>
 	<br />

--- a/views/dashboard/connect.php
+++ b/views/dashboard/connect.php
@@ -44,7 +44,7 @@
 
 	<p> Connect WordPress to your Beacon account so you can convert blog posts into lead magnets.  </p>
 
-	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/wordpress" method="post">
+	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/wordpress' ); ?>" method="post">
 		<input type="hidden" name="blog" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>" />
 		<input type="hidden" name="ref" value="<?php echo esc_url( Beacon_plugin::getPageURL() ); ?>" />
 		<button class="button large">Connect</button>
@@ -54,7 +54,7 @@
 
 	<p class="large flush">I don't have a Beacon account </p>
 
-	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/auth/register-wordpress" method="post">
+	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/auth/register-wordpress' ); ?>" method="post">
 		<input type="hidden" name="page" value="<?php echo esc_url( $_SERVER['HTTP_HOST'] ); ?>"/>
 		<input type="hidden" name="domain" value="<?php echo esc_url( $_SERVER['PHP_SELF'] ); ?>"/>
 		<button type="submit" class="text-button">Create a free account &gt;</button>

--- a/views/dashboard/create.php
+++ b/views/dashboard/create.php
@@ -86,7 +86,7 @@ Please select at least one post
 	</script>
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/api/ebook" method="post" target="_blank" class="select-posts">
 
-	<input type="hidden" name="url" value="<?php echo esc_attr( esc_url( get_site_url() ) ); ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_url( get_site_url() ); ?>" />
 	<input type="hidden" name="title" value="<?php echo esc_attr( get_bloginfo('name') ); ?>" />
 	<input type="hidden" name="decription" value="<?php echo esc_attr( get_bloginfo('description') ); ?>" />
 

--- a/views/dashboard/create.php
+++ b/views/dashboard/create.php
@@ -39,19 +39,19 @@ Please select at least one post
 
 		<dl>          
 			<dt>Available RAM </dt>
-			<dd><?php echo $data['mem']; ?>mb</dd>
+			<dd><?php echo esc_html( $data['mem'] ); ?>mb</dd>
 					
 			<dt>Low memory mode</dt>
-			<dd><?php echo $data['low_mem_mode_display']; ?></dd>
+			<dd><?php echo esc_html( $data['low_mem_mode_display'] ); ?></dd>
 
 			<dt>Posts shown</dt>
-			<dd><?php echo count($posts); ?></dd>
+			<dd><?php echo esc_html( count($posts) ); ?></dd>
 						
 			<dt>Total posts</dt>
-			<dd><?php echo $data['total']; ?></dd>
+			<dd><?php echo esc_html( $data['total'] ); ?></dd>
 						
 			<dt>Max posts</dt>
-			<dd><?php echo $data['post_limit']; ?></dd>
+			<dd><?php echo esc_html( $data['post_limit'] ); ?></dd>
 		</dl>
 	</div>
 <?php endif; ?>
@@ -69,8 +69,8 @@ Please select at least one post
 	<!--div class="error">
 		<h2>Oh dear! That is a lot of posts - Wordpress ran out of memory :(</h2>
 		<p>
-			Showing the most recent <?php echo count($posts); ?>
-			of all <?php echo $data['total']; ?> posts and pages
+			Showing the most recent <?php echo esc_html( count($posts) ); ?>
+			of all <?php echo esc_html( $data['total'] ); ?> posts and pages
 		</p>
 	</div-->
 <?php endif; ?>
@@ -81,10 +81,10 @@ Please select at least one post
 
 	<script>
 	var BeaconByPosts = <?php echo json_encode( $posts ); ?>;
-	BN.totalPosts = <?php echo $data['total']; ?>;
-	BN.perPage = <?php echo $data['per_page']; ?>;
+	BN.totalPosts = <?php echo esc_html( $data['total'] ); ?>;
+	BN.perPage = <?php echo esc_html( $data['per_page'] ); ?>;
 	</script>
-	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/api/ebook" method="post" target="_blank" class="select-posts">
+	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/api/ebook' ); ?>" method="post" target="_blank" class="select-posts">
 
 	<input type="hidden" name="url" value="<?php echo esc_url( get_site_url() ); ?>" />
 	<input type="hidden" name="title" value="<?php echo esc_attr( get_bloginfo('name') ); ?>" />
@@ -180,7 +180,7 @@ Please select at least one post
 	$categories = get_categories(); 
 	foreach ( $categories as $cat ):
 	?>
-	<span class="toggle-cat"><?php echo $cat->name; ?></span>
+	<span class="toggle-cat"><?php echo esc_html( $cat->name ); ?></span>
 	<?php endforeach; ?>
 
 
@@ -195,7 +195,7 @@ Please select at least one post
 	$tags = get_tags(); 
 	foreach ( $tags as $tag ):
 	?>
-	<span class="toggle-tag"><?php echo $tag->name; ?></span>
+	<span class="toggle-tag"><?php echo esc_html( $tag->name ); ?></span>
 	<?php
 	endforeach;
 	?>

--- a/views/dashboard/create.php
+++ b/views/dashboard/create.php
@@ -86,7 +86,7 @@ Please select at least one post
 	</script>
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/api/ebook" method="post" target="_blank" class="select-posts">
 
-	<input type="hidden" name="url" value="<?php echo esc_attr( get_site_url() ); ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_attr( esc_url( get_site_url() ) ); ?>" />
 	<input type="hidden" name="title" value="<?php echo esc_attr( get_bloginfo('name') ); ?>" />
 	<input type="hidden" name="decription" value="<?php echo esc_attr( get_bloginfo('description') ); ?>" />
 
@@ -130,22 +130,22 @@ Please select at least one post
 			$encoded = base64_encode ( serialize( $post ) );
 	?>
 
-	<div class="form-row type-<?php echo $post->post_type; ?>">
+	<div class="form-row type-<?php echo esc_attr( $post->post_type ); ?>">
 		<input type="checkbox" 
 				class="post_toggle" 
-				id="beacon_export_<?php echo $post->ID?>" />
+				id="beacon_export_<?php echo esc_attr( $post->ID ); ?>" />
 		<input type="hidden" 
 				class="post_data" 
-				data-cats="<?php echo $post->cats; ?>" 
-				data-tags="<?php echo $post->tags; ?>" 
-				data-title="<?php echo $post->post_title; ?>"
-				name="posts[<?php echo $post->id; ?>]" 
-				value="<?php echo $encoded; ?>" />
+				data-cats="<?php echo esc_attr( $post->cats ); ?>" 
+				data-tags="<?php echo esc_attr( $post->tags ); ?>" 
+				data-title="<?php echo esc_attr( $post->post_title ); ?>"
+				name="posts[<?php echo esc_attr( $post->id ); ?>]" 
+				value="<?php echo esc_attr( $encoded ); ?>" />
 
-		<label for="beacon_export_<?php echo $post->ID ?>">
-		<b><?php echo $post->post_title; ?></b>
-		<small><?php echo $post->cats; ?></small>
-		<small><?php echo $post->tags; ?></small>
+		<label for="beacon_export_<?php echo esc_attr( $post->ID ); ?>">
+		<b><?php echo esc_attr( $post->post_title ); ?></b>
+		<small><?php echo esc_attr( $post->cats ); ?></small>
+		<small><?php echo esc_attr( $post->tags ); ?></small>
 		</label>
 	</div>
 

--- a/views/dashboard/create.php
+++ b/views/dashboard/create.php
@@ -86,9 +86,9 @@ Please select at least one post
 	</script>
 	<form action="<?php echo BEACONBY_CREATE_TARGET; ?>/api/ebook" method="post" target="_blank" class="select-posts">
 
-	<input type="hidden" name="url" value="<?php echo get_site_url() ?>" />
-	<input type="hidden" name="title" value="<?php echo get_bloginfo('name') ?>" />
-	<input type="hidden" name="decription" value="<?php echo get_bloginfo('description') ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_attr( get_site_url() ); ?>" />
+	<input type="hidden" name="title" value="<?php echo esc_attr( get_bloginfo('name') ); ?>" />
+	<input type="hidden" name="decription" value="<?php echo esc_attr( get_bloginfo('description') ); ?>" />
 
 
 

--- a/views/dashboard/create.php
+++ b/views/dashboard/create.php
@@ -81,8 +81,8 @@ Please select at least one post
 
 	<script>
 	var BeaconByPosts = <?php echo json_encode( $posts ); ?>;
-	BN.totalPosts = <?php echo esc_html( $data['total'] ); ?>;
-	BN.perPage = <?php echo esc_html( $data['per_page'] ); ?>;
+	BN.totalPosts = <?php echo esc_attr( (int) $data['total'] ); ?>;
+	BN.perPage = <?php echo esc_attr( (int) $data['per_page'] ); ?>;
 	</script>
 	<form action="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/api/ebook' ); ?>" method="post" target="_blank" class="select-posts">
 
@@ -107,7 +107,7 @@ Please select at least one post
 			// }
 			// else
 			// {
-			// 	$post->cats = '';
+			//  $post->cats = '';
 			// }
 
 
@@ -143,9 +143,9 @@ Please select at least one post
 				value="<?php echo esc_attr( $encoded ); ?>" />
 
 		<label for="beacon_export_<?php echo esc_attr( $post->ID ); ?>">
-		<b><?php echo esc_attr( $post->post_title ); ?></b>
-		<small><?php echo esc_attr( $post->cats ); ?></small>
-		<small><?php echo esc_attr( $post->tags ); ?></small>
+		<b><?php echo esc_html( $post->post_title ); ?></b>
+		<small><?php echo esc_html( $post->cats ); ?></small>
+		<small><?php echo esc_html( $post->tags ); ?></small>
 		</label>
 	</div>
 

--- a/views/dashboard/embed.php
+++ b/views/dashboard/embed.php
@@ -19,7 +19,7 @@
 	<h3>Step 1. Select Content Upgrade:</h3>
 
 
-	<input type="hidden" name="url" value="<?php echo isset( $url ) ? esc_attr( esc_url( $url ) ) : ''; ?>" />
+	<input type="hidden" name="url" value="<?php echo isset( $url ) ? esc_url( $url ) : ''; ?>" />
 
 	<ul class="issues">
 	</ul>

--- a/views/dashboard/embed.php
+++ b/views/dashboard/embed.php
@@ -26,7 +26,7 @@
 
 	<div class="collapse help-image">
 		<a href="#" class="close"><i class="fa fa-times"></i> close</a>
-		<img src="<?php echo BEACONBY_PLUGIN_URL . 'i/embed-help.gif'; ?>" />
+		<img src="<?php echo esc_url( BEACONBY_PLUGIN_URL . 'i/embed-help.gif' ); ?>" />
 	</div>
 </div>
 

--- a/views/dashboard/embed.php
+++ b/views/dashboard/embed.php
@@ -19,7 +19,7 @@
 	<h3>Step 1. Select Content Upgrade:</h3>
 
 
-	<input type="hidden" name="url" value="<?php echo isset( $url ) ? $url : ''; ?>" />
+	<input type="hidden" name="url" value="<?php echo isset( $url ) ? esc_attr( $url ) : ''; ?>" />
 
 	<ul class="issues">
 	</ul>

--- a/views/dashboard/embed.php
+++ b/views/dashboard/embed.php
@@ -19,7 +19,7 @@
 	<h3>Step 1. Select Content Upgrade:</h3>
 
 
-	<input type="hidden" name="url" value="<?php echo isset( $url ) ? esc_attr( $url ) : ''; ?>" />
+	<input type="hidden" name="url" value="<?php echo isset( $url ) ? esc_attr( esc_url( $url ) ) : ''; ?>" />
 
 	<ul class="issues">
 	</ul>

--- a/views/dashboard/footer.tpl.php
+++ b/views/dashboard/footer.tpl.php
@@ -1,7 +1,7 @@
 
 <script>
 <?php if ($data['has_connected']): ?>
-BN_target = '<?php echo BEACONBY_CREATE_TARGET . '/api/beacon/' . $data['has_connected']?>';
+BN_target = '<?php echo esc_url( BEACONBY_CREATE_TARGET . '/api/beacon/' . $data['has_connected'] ); ?>';
 <?php else: ?>
 BN_target = false;
 <?php endif; ?>

--- a/views/dashboard/header.tpl.php
+++ b/views/dashboard/header.tpl.php
@@ -5,7 +5,7 @@
 		<?php 
 			if (isset($title)) 
 			{
-				echo '&raquo; '. $title;
+				echo esc_html( '&raquo; ' . $title );
 			}
 		?>
 	</h1>
@@ -14,7 +14,7 @@
 
 	<div class="prompt-login">
 		<div class="info">
-			<p>To use this feature you must be logged into your <a href="<?php echo BEACONBY_CREATE_TARGET; ?>/login" target="_blank">Beacon account</a></p>
+			<p>To use this feature you must be logged into your <a href="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/login' ); ?>" target="_blank">Beacon account</a></p>
 		</div>
 	</div>
 

--- a/views/dashboard/help.php
+++ b/views/dashboard/help.php
@@ -17,7 +17,7 @@ Please check out help center to get answers to frequently asked questions:
 
 <p class="large">
 <b>1. </b> First, we're going to need your unique Beacon name. 
-<a href="<?php echo BEACONBY_CREATE_TARGET; ?>/dashboard/publication-name" target="_blank">
+<a href="<?php echo esc_url( BEACONBY_CREATE_TARGET . '/dashboard/publication-name' ); ?>" target="_blank">
 Click this link to get it
 </a>
 

--- a/views/dashboard/main.php
+++ b/views/dashboard/main.php
@@ -9,7 +9,7 @@
 
 <ul class="options">
 	<li>
-		<a href="<?php echo admin_url( 'admin.php?page=beaconby-create' ); ?>">
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=beaconby-create' ) ); ?>">
 			<b>Create a new lead magnet</b><br />
 		<small>
 			Convert existing blog posts into a eBooks, Checklists and Resource Guides.

--- a/views/dashboard/promote.php
+++ b/views/dashboard/promote.php
@@ -42,7 +42,7 @@
 	<h1>2. Customize</h1>
 	<form method="post" id="beacon-promote">
 
-	<input type="hidden" name="url" value="<?php echo esc_attr( $data['url'] ); ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" />
 
 	<div class="form-row">
 		<label for="headline">Headline</label>

--- a/views/dashboard/promote.php
+++ b/views/dashboard/promote.php
@@ -42,7 +42,7 @@
 	<h1>2. Customize</h1>
 	<form method="post" id="beacon-promote">
 
-	<input type="hidden" name="url" value="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_url( $data['url'] ); ?>" />
 
 	<div class="form-row">
 		<label for="headline">Headline</label>

--- a/views/dashboard/promote.php
+++ b/views/dashboard/promote.php
@@ -63,7 +63,7 @@
 </div>
 
 
-<div class="step step3">	
+<div class="step step3">    
 	<h1>3. Preview</h1>
 
 	<?php

--- a/views/dashboard/promote.php
+++ b/views/dashboard/promote.php
@@ -42,21 +42,21 @@
 	<h1>2. Customize</h1>
 	<form method="post" id="beacon-promote">
 
-	<input type="hidden" name="url" value="<?php echo $data['url']; ?>" />
+	<input type="hidden" name="url" value="<?php echo esc_attr( $data['url'] ); ?>" />
 
 	<div class="form-row">
 		<label for="headline">Headline</label>
-		<input type="text" name="headline" value="<?php echo $data['headline']; ?>" />
+		<input type="text" name="headline" value="<?php echo esc_attr( $data['headline'] ); ?>" />
 	</div>
 
 	<div class="form-row">
 		<label for="title">Blurb</label>
-		<input type="text" name="title" value="<?php echo $data['title']; ?>" />
+		<input type="text" name="title" value="<?php echo esc_attr( $data['title'] ); ?>" />
 	</div>
 
 	<div class="form-row">
 		<label for="title">Button text</label>
-		<input type="text" name="button" value="<?php echo $data['button']; ?>" />
+		<input type="text" name="button" value="<?php echo esc_attr( $data['button'] ); ?>" />
 	</div>
 
 	</form>

--- a/views/widget/widget.php
+++ b/views/widget/widget.php
@@ -12,15 +12,15 @@
 
 ?>
 	<div class="beacon-promote">
-		<h2 class="beacon-title"><?php echo $data['headline']; ?></h2>
+		<h2 class="beacon-title"><?php echo esc_html( $data['headline'] ); ?></h2>
 		<div class="thumb">
-			<iframe width="70" height="100" src="<?php echo $thumb; ?>" frameborder="0" class="beacon-url"> </iframe>
+			<iframe width="70" height="100" src="<?php echo esc_url( $thumb ); ?>" frameborder="0" class="beacon-url"> </iframe>
 		</div>
-		<h3 class="beacon-headline"=><?php echo $data['title']; ?></h3>
-		<form action="<?php echo $target; ?>" method="post">
+		<h3 class="beacon-headline"=><?php echo esc_html( $data['title'] ); ?></h3>
+		<form action="<?php echo esc_url( $target ); ?>" method="post">
 			<input type="hidden" name="beaconby-url" value="<?php echo esc_url( $data['url'] ); ?>" />
 			<input type="email" name="beaconby-email" placeholder="Your Email" />
-		<button class="beacon-title" type="submit"><?php echo $data['button']; ?></button>
+			<button class="beacon-title" type="submit"><?php echo esc_html( $data['button'] ); ?></button>
 		</form>
 	</div>
 

--- a/views/widget/widget.php
+++ b/views/widget/widget.php
@@ -1,4 +1,10 @@
 <?php 
+
+	// Exit if accessed directly.
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
+
 	$parts = explode('/', $data['url']);
 	$origin = 'https://'.$parts[2];
 	$issue_url = $parts[count($parts) - 1];
@@ -16,7 +22,7 @@
 		<div class="thumb">
 			<iframe width="70" height="100" src="<?php echo esc_url( $thumb ); ?>" frameborder="0" class="beacon-url"> </iframe>
 		</div>
-		<h3 class="beacon-headline"=><?php echo esc_html( $data['title'] ); ?></h3>
+		<h3 class="beacon-headline"><?php echo esc_html( $data['title'] ); ?></h3>
 		<form action="<?php echo esc_url( $target ); ?>" method="post">
 			<input type="hidden" name="beaconby-url" value="<?php echo esc_url( $data['url'] ); ?>" />
 			<input type="email" name="beaconby-email" placeholder="Your Email" />

--- a/views/widget/widget.php
+++ b/views/widget/widget.php
@@ -18,7 +18,7 @@
 		</div>
 		<h3 class="beacon-headline"=><?php echo $data['title']; ?></h3>
 		<form action="<?php echo $target; ?>" method="post">
-			<input type="hidden" name="beaconby-url" value="<?php echo $data['url']; ?>" />
+			<input type="hidden" name="beaconby-url" value="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" />
 			<input type="email" name="beaconby-email" placeholder="Your Email" />
 		<button class="beacon-title" type="submit"><?php echo $data['button']; ?></button>
 		</form>

--- a/views/widget/widget.php
+++ b/views/widget/widget.php
@@ -18,7 +18,7 @@
 		</div>
 		<h3 class="beacon-headline"=><?php echo $data['title']; ?></h3>
 		<form action="<?php echo $target; ?>" method="post">
-			<input type="hidden" name="beaconby-url" value="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" />
+			<input type="hidden" name="beaconby-url" value="<?php echo esc_url( $data['url'] ); ?>" />
 			<input type="email" name="beaconby-email" placeholder="Your Email" />
 		<button class="beacon-title" type="submit"><?php echo $data['button']; ?></button>
 		</form>


### PR DESCRIPTION
QA Tier: P0

We got a report about a security issue, reported here: https://patchstack.com/database/report-preview/258c72b8-cc31-4dbd-bd64-a8eb69cb8d24

### Issue details
The `Beacon Lead Magnets and Lead Capture` plugin for WordPress is vulnerable to Reflected Cross-Site Scripting due to the use of `$_SERVER['PHP_SELF']` without appropriate escaping on the URL in all versions up to, and including, **1.5.7**. This makes it possible for unauthenticated attackers to inject arbitrary web scripts that execute if they can successfully trick a user into performing an action, such as clicking on a specially crafted link.

1. Install and activate the `Beacon Lead Magnets and Lead Capture` in WordPress.
2. Craft a malicious url by appending the following payload `"><script>alert(/XSS/)</script>`
3. e.g `http://example.com/wp-admin/admin.php/"><script>alert(/XSS/)</script>?page=beaconby-connect`
4. Trick an authenticated administrator into visiting the malicious page (e.g., via a phishing email or link).
5. the payload triggers once the page loads up.

This PR should fix the issue

### Testing procedure
1. Replicate the steps mentioned above
2. Pull this PR
3. Check if you can still replicate